### PR TITLE
Resetting `MultiExample.count` to initial state 0

### DIFF
--- a/cynergy/tests/test_life_cycle.py
+++ b/cynergy/tests/test_life_cycle.py
@@ -29,6 +29,7 @@ class NoLifeCycleExample(object):
 
 def test_multi():
     assert_instance_of(MultiExample, 2)
+    MultiExample.count = 0
 
 
 def test_single():


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_multi` by resetting `MultiExample.count` to initial state 0

The test can fail in this way if `MultiExample.count` is not reset
```
test_life_cycle.py::test_multi FAILED                                    [100%]
cynergy/tests/test_life_cycle.py:29 (test_multi)
4 != 2

Expected :2
Actual   :4
<Click to see difference>

def test_multi():
        assert_instance_of(MultiExample, 2)
>       assert_instance_of(MultiExample, 2)